### PR TITLE
fix: prioritize loader state over existing response in UI rendering

### DIFF
--- a/src/panels.rs
+++ b/src/panels.rs
@@ -307,7 +307,9 @@ impl MercuryApp {
     
     /// Response body with proper scroll
     fn render_response_body(&mut self, ui: &mut Ui) {
-        if let Some(response) = &self.response {
+        if self.executing {
+            loading_state(ui, "Sending request...");
+        } else if let Some(response) = &self.response {
             // Status row
             ui.horizontal(|ui| {
                 status_badge(ui, response.status, &response.status_text);
@@ -401,8 +403,6 @@ impl MercuryApp {
                     }
                 });
                 
-        } else if self.executing {
-            loading_state(ui, "Sending request...");
         } else if let Some(error) = &self.request_error {
             error_state(ui, error);
         } else {


### PR DESCRIPTION
## Description
Fixes #1.

This PR resolves the issue where the loader/processing UI was not displayed for subsequent requests when a response was already present in the panel.

## Changes
- Modified `src/panels.rs` to prioritize the `executing` state over the existing `response` state in the conditional rendering logic.
- Ensured that clicking 'Send' immediately shows the loader, regardless of whether a response is currently displayed.

## Verification
1. Open the app.
2. Send a request (e.g., to `https://httpbin.org/get`).
3. Wait for the response.
4. Click 'Send' again without clearing.
5. **Verify**: The loader ("Sending request...") appears immediately, replacing the previous response.