### PR TITLE
fix: Update docs URL and README structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@
 </p>
 
 <p align="center">
-  <a href="https://harry-kp.github.io/mercury/">Documentation</a> •
+  <a href="https://harry-kp.github.io/mercury/docs/getting-started">Documentation</a> •
   <a href="https://github.com/Harry-kp/mercury/releases">Download</a> •
   <a href="#philosophy">Philosophy</a> •
   <a href="#shortcuts">Shortcuts</a>
 </p>
 
-
+<p align="center">
   <a href="https://github.com/Harry-kp/mercury/releases"><img src="https://img.shields.io/github/v/release/Harry-kp/mercury?style=flat-square&color=00ff88" alt="Release"></a>
   <a href="https://github.com/Harry-kp/mercury/actions"><img src="https://img.shields.io/github/actions/workflow/status/Harry-kp/mercury/ci.yml?branch=master&style=flat-square&label=build" alt="Build Status"></a>
   <a href="https://github.com/Harry-kp/mercury/blob/master/LICENSE"><img src="https://img.shields.io/github/license/Harry-kp/mercury?style=flat-square" alt="License"></a>

--- a/src/app.rs
+++ b/src/app.rs
@@ -2272,9 +2272,6 @@ impl eframe::App for MercuryApp {
                     ui.add_space(crate::theme::Spacing::MD);
 
                     ui.horizontal(|ui| {
-                        if ui.link("View Online Docs ↗").clicked() {
-                            let _ = open::that(crate::constants::get_docs_url());
-                        }
                         ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                             if ui.button("Close").clicked() {
                                 self.show_shortcuts = false;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -19,7 +19,7 @@ pub fn get_releases_url() -> String {
 
 pub fn get_docs_url() -> String {
     format!(
-        "https://{}.github.io/{}/",
+        "https://{}.github.io/{}/docs/getting-started",
         GITHUB_USERNAME.to_lowercase(),
         GITHUB_REPO
     )


### PR DESCRIPTION
## Summary

Addresses user feedback on docs URL and README structure.

## Changes

1. **Docs URL** - Changed from landing page to actual docs page (`/docs/getting-started`)
2. **Shortcuts overlay** - Removed unnecessary docs link 
3. **README** - Fixed missing `<p align="center">` tag around badges section

## Files Changed
- `src/constants.rs` - Updated `get_docs_url()` path
- `src/app.rs` - Removed docs link from shortcuts overlay
- `README.md` - Fixed structure and updated docs link