### PR TITLE
perf: Reduce unnecessary clones in render functions

### DIFF
--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -409,8 +409,7 @@ impl MercuryApp {
     }
 
     fn build_collection_tree(&mut self) {
-        // Clone the PathBuf (necessary for borrow checker) but avoid cloning the Option unnecessarily
-        if let Some(workspace) = self.workspace_path.as_ref().map(|p| p.clone()) {
+        if let Some(workspace) = self.workspace_path.clone() {
             // Save current expanded state before rebuilding
             let old_tree = std::mem::take(&mut self.collection_tree);
             self.save_expanded_state(&old_tree);
@@ -899,7 +898,7 @@ impl MercuryApp {
                     );
                     let folder_response = ui.interact(
                         full_rect,
-                        egui::Id::new(("folder", path.clone())),
+                        egui::Id::new(("folder", path.as_path())),
                         egui::Sense::click(),
                     );
 
@@ -997,7 +996,7 @@ impl MercuryApp {
                     );
                     let request_response = ui.interact(
                         full_rect,
-                        egui::Id::new(("request", path.clone())),
+                        egui::Id::new(("request", path.as_path())),
                         egui::Sense::click(),
                     );
 


### PR DESCRIPTION
Fixes #95

## Summary
Optimized hot render path by removing path clones in collection tree rendering.

## Changes
- Replaced path.clone() with path.as_path() in egui::Id generation
  - Folder items (line 902)
  - Request items (line 1000)
  
## Impact
- Reduces allocations in hot render path (runs 60fps)
- No functional changes
- All 73 tests passing

## Analysis
- Investigated font_id.clone() (22 instances) - necessary, FontId is small
- Other path clones are necessary for owned values in state
- This PR focuses on the highest-impact optimization