### PR TITLE
fix: Escape < and > in performance.md for MDX parser

### DIFF
--- a/website/docs/performance.md
+++ b/website/docs/performance.md
@@ -102,8 +102,8 @@ The architecture prioritizes **perceived performance** over synthetic benchmarks
 
 Mercury intelligently adapts to response size:
 
-- **Small responses (<100KB)** — Full syntax highlighting with color-coded JSON/XML/HTML
-- **Large responses (>100KB)** — Plain text display to maintain 60fps
+- **Small responses (\<100KB)** — Full syntax highlighting with color-coded JSON/XML/HTML
+- **Large responses (\>100KB)** — Plain text display to maintain 60fps
 
 Syntax highlighting is character-intensive. By skipping it for large responses, Mercury stays responsive even when your API returns megabytes of data.
 


### PR DESCRIPTION
Fixes docs build failure.

MDX parser was failing on line 105 with `<100KB` because it tried to parse it as JSX.

**Changes:**
- Escaped `<100KB` to `\<100KB`
- Escaped `>100KB` to `\>100KB`

Fixes the Deploy Documentation workflow failure.