### PR TITLE
Revert distribution automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,7 +221,6 @@ jobs:
     if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      HOMEBREW_TAP_TOKEN: ${{ secrets.PROJECT_PAT }}
     runs-on: "ubuntu-22.04"
     outputs:
       val: ${{ steps.host.outputs.manifest }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Advanced HTTP Methods**: Support for `CONNECT` and `TRACE` methods in the request editor and dropdown.
 - **JSON Beautification**: Added a sparkle icon (✨) for one-click pretty-printing of request bodies.
 - **Standardized UI**: Unified iconography across the application (Chevrons, Cross, Checkmarks, and Tooltips).
-- **Enhanced Documentation**: Updated `README.md` and Docusaurus with professional package manager installation instructions.
-- **Automated Distribution**: Added Homebrew (macOS) and Winget (Windows) support via `cargo-dist` for a professional, single-trigger release process.
 - **Dot Indicator**: Visual cue for unsaved changes with a descriptive tooltip.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -73,24 +73,14 @@ Mercury is built on principles, not features:
 curl --proto '=https' --tlsv1.2 -LsSf https://github.com/Harry-kp/mercury/releases/latest/download/mercury-installer.sh | sh
 ```
 
+**Windows (PowerShell):**
+```powershell
+irm https://github.com/Harry-kp/mercury/releases/latest/download/mercury-installer.ps1 | iex
+```
+
 **Then launch:**
 ```bash
 mercury
-```
-
----
-
-### 📦 Package Managers
-
-**macOS (Homebrew):**
-```bash
-brew tap harry-kp/mercury
-brew install mercury
-```
-
-**Windows (Winget):**
-```powershell
-winget install Harry-kp.Mercury
 ```
 > 💡 If you get "command not found", restart your terminal or run `source ~/.zshrc`
 

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -8,7 +8,7 @@ cargo-dist-version = "0.30.2"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app
-installers = ["shell", "powershell", "homebrew", "winget"]
+installers = ["shell", "powershell"]
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
 # Path that installers should place binaries in
@@ -17,11 +17,3 @@ install-path = "CARGO_HOME"
 hosting = "github"
 # Whether to install an updater program
 install-updater = false
-
-[dist.homebrew]
-tap = "Harry-kp/homebrew-mercury"
-publish-binaries = true
-
-[dist.winget]
-publisher = "Harry-kp"
-package-id = "Mercury"

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -47,19 +47,6 @@ curl --proto '=https' --tlsv1.2 -LsSf https://github.com/Harry-kp/mercury/releas
 irm https://github.com/Harry-kp/mercury/releases/latest/download/mercury-installer.ps1 | iex
 ```
 
-### 📦 Package Managers
-
-**macOS (Homebrew):**
-```bash
-brew tap harry-kp/mercury
-brew install mercury
-```
-
-**Windows (Winget):**
-```powershell
-winget install Harry-kp.Mercury
-```
-
 **Then launch:**
 ```bash
 mercury


### PR DESCRIPTION
This PR reverts the experimental Homebrew and Winget distribution support, returning the release pipeline to its standardized state while preserving recent UI refinements.