### PR TITLE
feat: defer timeline/history loading for faster startup

### DIFF
--- a/src/ui/panels.rs
+++ b/src/ui/panels.rs
@@ -335,6 +335,7 @@ impl MercuryApp {
 
     /// Timeline content with proper scroll
     fn render_timeline_content(&mut self, ui: &mut Ui) {
+        self.ensure_history_loaded();
         // Track if we should clear history (to avoid borrow issues)
         let mut should_clear = false;
 


### PR DESCRIPTION
## Overview
This PR implements lazy loading for the request history (timeline) to improve application startup performance. History data is no longer loaded eagerly during initialization; instead, it's loaded only when the history panel is first accessed or when a new request completes.

## Performance Improvements
Benchmarked application initialization (`MercuryApp::new`) with a 53KB history file (~700 entries):
- **Baseline**: ~5.68ms
- **Optimized**: ~4.55ms
- **Reduction**: **~20% (1.13ms)**

The performance gains scale linearly with history size, preventing UI lag for power users with large history files.

## Changes
- Added `history_loaded` flag to `MercuryApp` to track lazy loading state.
- Refactored `MercuryApp::new` to initialize an empty timeline.
- Integrated `ensure_history_loaded()` helper in:
    - `render_timeline_content` (when panel opens)
    - `update` loop (when a new request completes)
- Added safety check in `save_history()` to prevent data loss if history hasn't been loaded.

Closes #144