### PR TITLE
feat(ux): remove response diff feature

### DIFF
--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -47,11 +47,9 @@ pub struct MercuryApp {
     pub auth_token: String,
 
     pub response: Option<HttpResponse>,
-    pub previous_response: Option<HttpResponse>,
     pub response_view_raw: bool,
     pub show_response_headers: bool,
     pub show_response_cookies: bool,
-    pub show_response_diff: bool,
     // Cached formatted response to avoid cloning every frame
     pub formatted_response_cache: Option<String>,
 
@@ -156,11 +154,9 @@ impl MercuryApp {
             auth_password: String::new(),
             auth_token: String::new(),
             response: None,
-            previous_response: None,
             response_view_raw: false,
             show_response_headers: false,
             show_response_cookies: false,
-            show_response_diff: false,
             formatted_response_cache: None,
 
             env_files: vec!["None".to_string()],
@@ -422,7 +418,6 @@ impl MercuryApp {
         self.body_text = String::new();
         self.auth_text = String::new();
         self.response = None;
-        self.previous_response = None;
         self.has_unsaved_changes = false;
         self.last_saved_content = None;
     }
@@ -1323,8 +1318,7 @@ impl eframe::App for MercuryApp {
                             }
                         }
 
-                        // Track previous response for diff
-                        self.previous_response = self.response.take();
+                        // Update response
                         self.response = Some(response);
                         self.formatted_response_cache = None; // Invalidate cache
                         self.request_error = None;

--- a/src/ui/panels.rs
+++ b/src/ui/panels.rs
@@ -525,7 +525,6 @@ impl MercuryApp {
                 response.response_type,
                 ResponseType::Binary | ResponseType::Image | ResponseType::LargeText
             );
-            let has_previous = self.previous_response.is_some();
             let headers_count = response.headers.len();
             let cookies_count = response.cookies.len();
 
@@ -544,15 +543,12 @@ impl MercuryApp {
                     ui.checkbox(&mut self.show_response_cookies, cookies_label);
                 }
 
-                // Raw and Diff only make sense for text responses
+                // Raw only makes sense for text responses
                 if is_text_response {
                     let was_raw = self.response_view_raw;
                     ui.checkbox(&mut self.response_view_raw, "Raw");
                     if self.response_view_raw != was_raw {
                         raw_toggled = true;
-                    }
-                    if has_previous {
-                        ui.checkbox(&mut self.show_response_diff, "Diff");
                     }
                 }
 

--- a/website/docs/features/history.md
+++ b/website/docs/features/history.md
@@ -18,7 +18,7 @@ Every time you send a request, Mercury records:
 
 This lets you:
 - Review past API responses
-- Compare different responses
+- Review previous responses
 - Restore and rerun previous requests
 - Debug API behavior over time
 
@@ -77,9 +77,9 @@ Each history entry shows when it was executed using relative timestamps like "Ju
 
 ## Use Cases
 
-### Compare API Changes
+### Track API Changes
 
-Run the same request multiple times to compare responses as you develop your API.
+Run the same request multiple times to see how the response evolves as you develop your API.
 
 ### Debug Flaky Endpoints
 


### PR DESCRIPTION
Closes #152. 

This PR removes the Response Diff feature as it was determined to be rarely used, added unnecessary complexity, and lacked a robust implementation.

### Changes:
- Removed `previous_response` and `show_response_diff` from `MercuryApp`.
- Removed the "Diff" checkbox from the response panel UI.
- Updated documentation in `website/docs/features/history.md` to reflect the removal.
- Verified all tests pass and the application compiles correctly.